### PR TITLE
Test State in ViewModel

### DIFF
--- a/StateCodelab/start/src/test/java/com/codelabs/state/todo/TodoViewModelTest.kt
+++ b/StateCodelab/start/src/test/java/com/codelabs/state/todo/TodoViewModelTest.kt
@@ -16,6 +16,40 @@
 
 package com.codelabs.state.todo
 
+import com.codelabs.state.util.generateRandomTodoItem
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
 class TodoViewModelTest {
-    // TODO: Write tests
+
+    @Test
+    fun whenAddItem_updateList() {
+        val subject = TodoViewModel()
+        val item = generateRandomTodoItem()
+        subject.addItem(item = item)
+        assertThat(subject.todoItems).isEqualTo(listOf(item))
+    }
+
+    @Test
+    fun whenRemovingItem_updatesList() {
+        // before
+        val viewModel = TodoViewModel()
+        val item1 = generateRandomTodoItem()
+        val item2 = generateRandomTodoItem()
+        viewModel.addItem(item1)
+        viewModel.addItem(item2)
+
+        // during
+        viewModel.removeItem(item1)
+
+        // after
+        assertThat(viewModel.todoItems).isEqualTo(listOf(item2))
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun whenNotEditing_onEditItemChangeThrows() {
+        val subject = TodoViewModel()
+        val item = generateRandomTodoItem()
+        subject.onEditItemChange(item)
+    }
 }


### PR DESCRIPTION
issue #30 


- `MutableState <T>`への書き込みが別のスレッドで実行された場合、それらはテストからすぐには表示されない
- 変更を表示するための低レベルAPIは`Snapshot.sendApplyNotifications()` これを処理するための高レベルAPIは現在実装中
- テストでState <T>オブジェクトへの書き込みを待機する現在のAPIはありません。
- todoItemsが非同期で入力された場合、たとえばデータベース呼び出しによって、現在、更新されるのを待つ方法はない

refs: https://developer.android.com/codelabs/jetpack-compose-state#9
